### PR TITLE
Hide past events

### DIFF
--- a/website/browse.html
+++ b/website/browse.html
@@ -71,8 +71,14 @@
                     <i class="fa-solid fa-arrow-right"></i>
                 </button>
             </section>
-            <h2 class="spaced-heading">Past Events</h2>
-            <section class="event-carousel">
+            <div class="past-events-header">
+                <h2 class="spaced-heading">Past Events</h2>
+                <button class="toggle-past-events" id="togglePastEvents">
+                    <span class="toggle-text">Show Events</span>
+                    <i class="fa-solid fa-chevron-down toggle-icon"></i>
+                </button>
+            </div>
+            <section class="event-carousel" id="pastEventsCarousel" style="display: none;">
                 <button class="prev">
                     <i class="fa-solid fa-arrow-left"></i>
                 </button>

--- a/website/css/browse.css
+++ b/website/css/browse.css
@@ -91,6 +91,57 @@ h2 {
         height 0.6s;
 }
 
+/* Past Events Toggle CSS */
+.past-events-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 30px 20px 20px;
+}
+
+.past-events-header h2 {
+    margin: 0;
+    color: white;
+    font-family: "Merriweather Sans", sans-serif;
+    font-size: 25px;
+}
+
+.toggle-past-events {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    background: #c69214f2;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    font-family: "Raleway", sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    box-shadow: 0 3px 12px rgba(198, 146, 20, 0.3);
+}
+
+.toggle-past-events:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 5px 18px rgba(198, 146, 20, 0.4);
+}
+
+.toggle-past-events:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(198, 146, 20, 0.2);
+}
+
+.toggle-icon {
+    transition: transform 0.3s ease;  
+    font-size: 12px;
+}
+
+.toggle-past-events[aria-expanded="true"] .toggle-icon {
+    transform: rotate(180deg);  
+}
+
 .event-carousel .prev:active::before,
 .event-carousel .next:active::before {
     width: 200px;

--- a/website/js/carousel.js
+++ b/website/js/carousel.js
@@ -52,6 +52,67 @@ function setupCarouselNavigation(prevBtn, nextBtn, eventCards) {
         });
     });
 }
+/**
+ * Initializes the toggle functionality for past events section
+ */
+function initializePastEventsToggle() {
+    const toggleBtn = document.getElementById('togglePastEvents');
+    const pastEventsCarousel = document.getElementById('pastEventsCarousel');
+    const toggleText = toggleBtn?.querySelector('.toggle-text');
+    const toggleIcon = toggleBtn?.querySelector('.toggle-icon');
+
+    if (!toggleBtn || !pastEventsCarousel || !toggleText || !toggleIcon) {
+        console.warn('Past events toggle elements not found');
+        return;
+    }
+
+    let isExpanded = false;
+
+    toggleBtn.addEventListener('click', () => {
+        isExpanded = !isExpanded;
+        
+        if (isExpanded) {
+            // Show the carousel
+            pastEventsCarousel.style.display = 'flex';
+            toggleText.textContent = 'Hide Events';
+            toggleBtn.setAttribute('aria-expanded', 'true');
+            
+            // Add smooth slide-down animation
+            pastEventsCarousel.style.opacity = '0';
+            pastEventsCarousel.style.transform = 'translateY(-20px)';
+            
+            // Force reflow then animate
+            setTimeout(() => {
+                pastEventsCarousel.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+                pastEventsCarousel.style.opacity = '1';
+                pastEventsCarousel.style.transform = 'translateY(0)';
+            }, 10);
+            
+            // Re-initialize carousel for past events when shown
+            setTimeout(() => {
+                initializeCarousels();
+            }, 100);
+            
+        } else {
+            // Hide the carousel
+            pastEventsCarousel.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+            pastEventsCarousel.style.opacity = '0';
+            pastEventsCarousel.style.transform = 'translateY(-20px)';
+            
+            setTimeout(() => {
+                pastEventsCarousel.style.display = 'none';
+                pastEventsCarousel.style.transition = '';
+            }, 300);
+            
+            toggleText.textContent = 'Show Events';
+            toggleBtn.setAttribute('aria-expanded', 'false');
+        }
+    });
+
+    // Set initial ARIA attributes
+    toggleBtn.setAttribute('aria-expanded', 'false');
+    toggleBtn.setAttribute('aria-controls', 'pastEventsCarousel');
+}
 
 /**
  * Updates the visual state of navigation buttons based on scroll position
@@ -166,6 +227,7 @@ function addTouchSupport(eventCards) {
 document.addEventListener("DOMContentLoaded", () => {
     setTimeout(() => {
         initializeCarousels();
+        initializePastEventsToggle();
 
         document.addEventListener("keydown", handleKeyboardNavigation);
 


### PR DESCRIPTION
# Hide Past events

Closes #122 
Team Member Names: Lucas Hlaing

# Summary

I hid past events by default and made it so it only shows after clicking a button.

## Code Changes

I changed the browse.html to include the button. I also changed browse.css to include css for the button as well as some animations for it. lastly, i changed carousel.js which rendered in the browse page so that it would handle the past events case. 

# Type of Change

- [X] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Other: (Fill In)

# Checklist

- [X] I have reviewed my own code.
- [X] I have removed unnecessary comments and print statements from my code.
- [X] I have tested my code.

# Screenshots
![image](https://github.com/user-attachments/assets/46ad3b81-bed9-42d7-ae27-0e7c31c2c2e7)
![image](https://github.com/user-attachments/assets/11ae1d23-55e7-474c-8fc6-348ce3286b30)

Insert some screenshots of completed work, if applicable.
